### PR TITLE
Fix GitHub Actions PostgreSQL health check timing - Increase health c…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,10 +16,10 @@ services:
     #check postgres is up before allowing app to connect
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U vatsim_user -d vatsim_data"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 30s
+      interval: 30s        # Increase from 10s
+      timeout: 10s         # Increase from 5s  
+      retries: 10          # Increase from 5
+      start_period: 60s    # Increase from 30s
 
   # Main Application (API-First Architecture)
   app:


### PR DESCRIPTION
…heck interval from 10s to 30s - Increase timeout from 5s to 10s - Increase retries from 5 to 10 - Increase start period from 30s to 60s - Resolves 'container vatsim_postgres is unhealthy' CI/CD failures