### PR TITLE
Fix API query for sector cleanup status endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -863,9 +863,14 @@ async def get_cleanup_status():
             stale_cutoff = datetime.now(timezone.utc) - timedelta(seconds=cleanup_timeout)
             stale_sectors_count = await session.scalar(text("""
                 SELECT COUNT(*) FROM flight_sector_occupancy fso
-                JOIN flights f ON fso.callsign = f.callsign
+                JOIN (
+                    SELECT DISTINCT ON (callsign) 
+                        callsign, last_updated
+                    FROM flights 
+                    ORDER BY callsign, last_updated DESC
+                ) latest_flight ON fso.callsign = latest_flight.callsign
                 WHERE fso.exit_timestamp IS NULL
-                AND f.last_updated < :stale_cutoff
+                AND latest_flight.last_updated < :stale_cutoff
             """), {"stale_cutoff": stale_cutoff})
         
         return {


### PR DESCRIPTION
- Replace Cartesian product join with DISTINCT ON to get latest flight per callsign
- Aligns API reporting with actual cleanup logic behavior
- Fixes false reporting of 1300+ stale sectors when only 12 open sectors exist
- No data changes, only corrects monitoring/API response accuracy