### PR TITLE
Fix controller type detection: add APP/DEP as TMA controllers

### DIFF
--- a/app/services/atc_detection_service.py
+++ b/app/services/atc_detection_service.py
@@ -604,6 +604,10 @@ class ATCDetectionService:
             return "CTR"
         elif "TMA" in callsign_upper:
             return "TMA"
+        elif "APP" in callsign_upper:
+            return "TMA"
+        elif "DEP" in callsign_upper:
+            return "TMA"
         elif "TWR" in callsign_upper:
             return "TWR"
         elif "GND" in callsign_upper:


### PR DESCRIPTION
- Add missing APP and DEP cases to _detect_controller_type() method
- APP and DEP controllers now correctly classified as TMA instead of OTHER
- Fixes airborne_controller_time_percentage calculation for flights with APP/DEP controllers
- Resolves issue where ML_APP, ML_DEP, etc. were not counted as airborne controllers