### PR TITLE
Fix: Remove summary_interval_minutes reference from validation

### DIFF
--- a/app/services/data_service.py
+++ b/app/services/data_service.py
@@ -2848,7 +2848,7 @@ RETURNING fso.id;
             if config.retention_hours < config.completion_hours:
                 raise ValueError("FLIGHT_RETENTION_HOURS must be greater than FLIGHT_COMPLETION_HOURS")
             
-            self.logger.info(f"✅ Flight summary configuration validated: interval={config.summary_interval_minutes}min, completion={config.completion_hours}h, retention={config.retention_hours}h")
+            self.logger.info(f"✅ Flight summary configuration validated: completion={config.completion_hours}h, retention={config.retention_hours}h")
             
         except Exception as e:
             self.logger.error(f"❌ Flight summary configuration validation failed: {e}")


### PR DESCRIPTION
- Fixed _validate_flight_summary_config method that was still referencing removed summary_interval_minutes field
- This was preventing scheduled flight processing from starting, causing pending enrichment to grow
- Validation now only checks completion_hours and retention_hours
- Resolves configuration validation error that blocked canonical processing startup