### PR TITLE
Fix enrichment worker transaction isolation bug

### DIFF
--- a/app/services/summary_enrichment_worker.py
+++ b/app/services/summary_enrichment_worker.py
@@ -86,215 +86,276 @@ class SummaryEnrichmentWorker:
         atc_data['controller_callsigns'] = filtered_controllers
         return atc_data
 
+    async def _recover_stuck_flights(self):
+        """Recover flights stuck in 'in_progress' status for too long."""
+        try:
+            async with get_database_session() as session:
+                # Reset flights stuck in 'in_progress' for more than 5 minutes
+                result = await session.execute(text("""
+                    UPDATE flight_summaries
+                    SET enrichment_status = 'pending',
+                        enrichment_run_after = NOW() + INTERVAL '30 seconds',
+                        enrichment_last_error = 'Recovered from stuck in_progress status',
+                        updated_at = NOW()
+                    WHERE enrichment_status = 'in_progress' 
+                    AND updated_at < NOW() - INTERVAL '5 minutes'
+                    RETURNING id, callsign
+                """))
+                
+                recovered_flights = result.fetchall()
+                if recovered_flights:
+                    logger.warning(f"Recovered {len(recovered_flights)} flights stuck in 'in_progress' status")
+                    for flight in recovered_flights:
+                        logger.info(f"Recovered stuck flight: id={flight.id}, callsign={flight.callsign}")
+                
+                await session.commit()
+                
+        except Exception as e:
+            logger.error(f"Error recovering stuck flights: {e}")
+
+    async def _reset_excessive_retries(self):
+        """Reset flights with excessive retry counts."""
+        try:
+            async with get_database_session() as session:
+                # Reset flights with 100+ attempts
+                result = await session.execute(text("""
+                    UPDATE flight_summaries
+                    SET enrichment_attempts = 0,
+                        enrichment_status = 'pending',
+                        enrichment_run_after = NOW() + INTERVAL '60 seconds',
+                        enrichment_last_error = 'Reset due to excessive retries',
+                        updated_at = NOW()
+                    WHERE enrichment_attempts >= 100
+                    AND enrichment_status = 'pending'
+                    AND completion_time IS NOT NULL
+                    RETURNING id, callsign, enrichment_attempts
+                """))
+                
+                reset_flights = result.fetchall()
+                if reset_flights:
+                    logger.warning(f"Reset {len(reset_flights)} flights with excessive retry counts")
+                    for flight in reset_flights:
+                        logger.info(f"Reset flight: id={flight.id}, callsign={flight.callsign}, attempts={flight.enrichment_attempts}")
+                
+                await session.commit()
+                
+        except Exception as e:
+            logger.error(f"Error resetting excessive retries: {e}")
+
     async def run_once(self):
-        # Attempt to claim a pending flight summary; if none, claim a pending controller summary.
+        """Process one enrichment job with improved error handling."""
+        # Periodically recover stuck flights
+        import random
+        if random.random() < 0.01:  # 1% chance per run
+            await self._recover_stuck_flights()
+            await self._reset_excessive_retries()
+
         fs_id = None
         controller_job = None
 
-        async with get_database_session() as session:
-            # Try flight summary
-            claim_flight_sql = text("""
-                SELECT id, callsign, departure, arrival, logon_time
-                FROM flight_summaries
-                WHERE enrichment_status = 'pending' AND enrichment_run_after <= now() AND completion_time IS NOT NULL
-                LIMIT 1
-                FOR UPDATE SKIP LOCKED
-            """)
-            res = await session.execute(claim_flight_sql)
-            row = res.fetchone()
-            if row:
-                fs_id = row.id
-                callsign = row.callsign
-                departure = row.departure
-                arrival = row.arrival
-                logon_time = row.logon_time
-
-                await session.execute(text("""
-                    UPDATE flight_summaries
-                    SET enrichment_status = 'in_progress', enrichment_attempts = COALESCE(enrichment_attempts, 0) + 1, updated_at = now()
-                    WHERE id = :id
-                """), {"id": fs_id})
-                await session.commit()
-            else:
-                # Try controller summary
-                claim_controller_sql = text("""
-                    SELECT id, callsign, session_start_time, session_end_time
-                    FROM controller_summaries
-                    WHERE enrichment_status = 'pending' AND enrichment_run_after <= now()
+        # FIX: Use a single transaction for claim and process
+        try:
+            async with get_database_session() as session:
+                # Try flight summary first
+                claim_flight_sql = text("""
+                    SELECT id, callsign, departure, arrival, logon_time
+                    FROM flight_summaries
+                    WHERE enrichment_status = 'pending' 
+                    AND enrichment_run_after <= now() 
+                    AND completion_time IS NOT NULL
                     LIMIT 1
                     FOR UPDATE SKIP LOCKED
                 """)
-                cres = await session.execute(claim_controller_sql)
-                crow = cres.fetchone()
-                if not crow:
-                    return False
-                controller_job = {
-                    "id": crow.id,
-                    "callsign": crow.callsign,
-                    "session_start": crow.session_start_time,
-                    "session_end": crow.session_end_time,
-                }
-
-                await session.execute(text("""
-                    UPDATE controller_summaries
-                    SET enrichment_status = 'in_progress', enrichment_attempts = COALESCE(enrichment_attempts, 0) + 1, updated_at = now()
-                    WHERE id = :id
-                """), {"id": controller_job["id"]})
-                await session.commit()
-
-        # Run enrichment outside the claim transaction
-        import json
-
-        try:
-            if fs_id:
-                logger.info(f"Enriching flight summary id={fs_id} callsign={callsign}")
-                atc_data = await self.atc_service.detect_flight_atc_interactions_with_timeout(callsign, departure, arrival, logon_time, timeout_seconds=30.0)
+                res = await session.execute(claim_flight_sql)
+                row = res.fetchone()
                 
-                # Apply controller validation filter before storing to JSONB
-                atc_data = self._filter_valid_controllers(atc_data)
-                
-                # DEBUG: write ATC detection result to a debug file for traceability
-                try:
-                    import json
-                    debug_path = f"/tmp/enrich_flight_{fs_id}_{callsign}.json"
-                    with open(debug_path, 'w') as df:
-                        json.dump({
-                            'fs_id': fs_id,
-                            'callsign': callsign,
-                            'atc_data': atc_data
-                        }, df, default=str, indent=2)
-                    logger.debug(f"Wrote flight enrichment debug file: {debug_path}")
-                except Exception:
-                    logger.exception("Failed to write flight enrichment debug file")
+                if row:
+                    fs_id = row.id
+                    callsign = row.callsign
+                    departure = row.departure
+                    arrival = row.arrival
+                    logon_time = row.logon_time
 
-                async with get_database_session() as session:
-                    # Guard: ensure completion_time is still present before writing completion
+                    # Mark as in_progress but don't commit yet
+                    await session.execute(text("""
+                        UPDATE flight_summaries
+                        SET enrichment_status = 'in_progress', 
+                            enrichment_attempts = COALESCE(enrichment_attempts, 0) + 1, 
+                            updated_at = now()
+                        WHERE id = :id
+                    """), {"id": fs_id})
+
+                    logger.info(f"Enriching flight summary id={fs_id} callsign={callsign}")
+                    
+                    # Run enrichment within the same transaction
                     try:
+                        atc_data = await self.atc_service.detect_flight_atc_interactions_with_timeout(
+                            callsign, departure, arrival, logon_time, timeout_seconds=30.0
+                        )
+                        
+                        # Apply controller validation filter
+                        atc_data = self._filter_valid_controllers(atc_data)
+                        
+                        # Guard: ensure completion_time is still present
                         ct_res = await session.execute(text("""
                             SELECT completion_time FROM flight_summaries WHERE id = :id
                         """), {"id": fs_id})
                         ct_val = ct_res.scalar()
-                    except Exception:
-                        ct_val = None
-                    if not ct_val:
-                        # Requeue with backoff instead of writing an empty/incorrect enrichment
+                        
+                        if not ct_val:
+                            # Requeue with backoff
+                            await session.execute(text("""
+                                UPDATE flight_summaries
+                                SET enrichment_status = 'pending',
+                                    enrichment_run_after = now() + interval '300 seconds',
+                                    enrichment_last_error = 'deferred: missing completion_time',
+                                    updated_at = now()
+                                WHERE id = :id
+                            """), {"id": fs_id})
+                            await session.commit()
+                            logger.info(f"Deferring flight enrichment id={fs_id} callsign={callsign}: completion_time missing")
+                            return False
+
+                        # Compute total enroute time
+                        total_enroute_minutes = 0
+                        try:
+                            if ct_val:
+                                total_enroute = await self.atc_service._get_airborne_time_from_flights(
+                                    callsign, departure, arrival, logon_time, ct_val
+                                )
+                                total_enroute_minutes = int(total_enroute) if total_enroute is not None else 0
+                        except Exception:
+                            logger.exception("Failed to compute total_enroute from flights for enrichment")
+                            total_enroute_minutes = 0
+
+                        # Use custom default serializer
+                        import json
+                        controller_callsigns_json = json.dumps(
+                            atc_data.get("controller_callsigns", {}), default=_json_default
+                        )
+
+                        # Complete the enrichment in the same transaction
                         await session.execute(text("""
                             UPDATE flight_summaries
-                            SET enrichment_status = 'pending',
-                                enrichment_run_after = now() + interval '300 seconds',
-                                enrichment_last_error = COALESCE(enrichment_last_error, '') || ' | deferred: missing completion_time',
+                            SET controller_callsigns = :controller_callsigns,
+                                controller_time_percentage = :ctp,
+                                airborne_controller_time_percentage = :actp,
+                                time_online_minutes = :time_online,
+                                total_enroute_time_minutes = :enroute,
+                                enrichment_status = 'completed',
+                                enrichment_completed_at = now(),
+                                enrichment_last_error = NULL,
                                 updated_at = now()
                             WHERE id = :id
-                        """), {"id": fs_id})
+                        """), {
+                            "controller_callsigns": controller_callsigns_json,
+                            "ctp": atc_data.get("controller_time_percentage", None),
+                            "actp": atc_data.get("airborne_controller_time_percentage", None),
+                            "time_online": atc_data.get("total_controller_time_minutes", None),
+                            "enroute": total_enroute_minutes,
+                            "id": fs_id
+                        })
+                        
+                        # Commit everything together - either all succeeds or all fails
                         await session.commit()
-                        logger.info(f"Deferring flight enrichment id={fs_id} callsign={callsign}: completion_time missing")
+                        logger.info(f"Enrichment completed id={fs_id} callsign={callsign}")
+                        return True
+                        
+                    except Exception as e:
+                        # On any error, reset to pending with proper error logging
+                        logger.exception(f"Enrichment failed for id={fs_id} callsign={callsign}: {e}")
+                        await session.execute(text("""
+                            UPDATE flight_summaries
+                            SET enrichment_status = 'pending', 
+                                enrichment_run_after = now() + interval '60 seconds', 
+                                enrichment_last_error = :err, 
+                                updated_at = now()
+                            WHERE id = :id
+                        """), {"err": str(e), "id": fs_id})
+                        await session.commit()
                         return False
-                    # Use custom default serializer to handle Decimal, datetime, etc.
-                    controller_callsigns_json = json.dumps(atc_data.get("controller_callsigns", {}), default=_json_default)
+                else:
+                    # Try controller summary (using similar transaction pattern)
+                    claim_controller_sql = text("""
+                        SELECT id, callsign, session_start_time, session_end_time
+                        FROM controller_summaries
+                        WHERE enrichment_status = 'pending' AND enrichment_run_after <= now()
+                        LIMIT 1
+                        FOR UPDATE SKIP LOCKED
+                    """)
+                    cres = await session.execute(claim_controller_sql)
+                    crow = cres.fetchone()
+                    if not crow:
+                        return False
+                        
+                    controller_job = {
+                        "id": crow.id,
+                        "callsign": crow.callsign,
+                        "session_start": crow.session_start_time,
+                        "session_end": crow.session_end_time,
+                    }
 
-                    # Compute total enroute time (minutes) using flights/flights_archive/transceivers
-                    total_enroute_minutes = None
-                    try:
-                        # Re-read completion_time (ct_val) which we checked exists above
-                        ct_res = await session.execute(text("SELECT completion_time FROM flight_summaries WHERE id = :id"), {"id": fs_id})
-                        ct_val = ct_res.scalar()
-                        if ct_val:
-                            total_enroute = await self.atc_service._get_airborne_time_from_flights(callsign, departure, arrival, logon_time, ct_val)
-                            try:
-                                total_enroute_minutes = int(total_enroute) if total_enroute is not None else 0
-                            except Exception:
-                                logger.exception("Failed to convert total_enroute to int")
-                                total_enroute_minutes = 0
-                        else:
-                            total_enroute_minutes = 0
-                    except Exception:
-                        logger.exception("Failed to compute total_enroute from flights for enrichment")
-                        total_enroute_minutes = 0
-
-                    if total_enroute_minutes == 0:
-                        logger.debug(f"Computed total_enroute_minutes=0 for fs_id={fs_id} callsign={callsign}; may indicate missing archive/transceiver records or short duration")
-
+                    # Mark as in_progress
                     await session.execute(text("""
-                        UPDATE flight_summaries
-                        SET controller_callsigns = :controller_callsigns,
-                            controller_time_percentage = :ctp,
-                            airborne_controller_time_percentage = :actp,
-                            time_online_minutes = :time_online,
-                            total_enroute_time_minutes = :enroute,
-                            enrichment_status = 'completed',
-                            enrichment_completed_at = now(),
+                        UPDATE controller_summaries
+                        SET enrichment_status = 'in_progress', 
+                            enrichment_attempts = COALESCE(enrichment_attempts, 0) + 1, 
                             updated_at = now()
                         WHERE id = :id
-                    """), {
-                        "controller_callsigns": controller_callsigns_json,
-                        "ctp": atc_data.get("controller_time_percentage", None),
-                        "actp": atc_data.get("airborne_controller_time_percentage", None),
-                        "time_online": atc_data.get("total_controller_time_minutes", None),
-                        "enroute": total_enroute_minutes,
-                        "id": fs_id
-                    })
-                    await session.commit()
+                    """), {"id": controller_job["id"]})
 
-                logger.info(f"Enrichment completed id={fs_id} callsign={callsign}")
-                return True
+                    logger.info(f"Enriching controller summary id={controller_job['id']} callsign={controller_job['callsign']}")
+                    
+                    try:
+                        flight_data = await self.flight_service.detect_controller_flight_interactions_with_timeout(
+                            controller_job['callsign'], controller_job['session_start'], controller_job['session_end'], timeout_seconds=30.0
+                        )
 
-            if controller_job:
-                cid = controller_job["id"]
-                callsign = controller_job["callsign"]
-                start = controller_job["session_start"]
-                end = controller_job["session_end"]
-
-                logger.info(f"Enriching controller summary id={cid} callsign={callsign}")
-                flight_data = await self.flight_service.detect_controller_flight_interactions_with_timeout(callsign, start, end, timeout_seconds=30.0)
-
-                # Log concise detection summary immediately before writing to DB
-                try:
-                    sample_callsigns = [d.get('callsign') for d in (flight_data.get('details') or [])[:10]]
-                    logger.debug(
-                        f"Controller enrichment write summary id={cid} callsign={callsign}: flights_detected={flight_data.get('flights_detected')}, total_aircraft={flight_data.get('total_aircraft')}, details_len={len(flight_data.get('details') or [])}, sample_callsigns={sample_callsigns}"
-                    )
-                except Exception:
-                    logger.exception("Failed to log controller enrichment write summary")
-
-                async with get_database_session() as session:
-                    # Use custom default serializer to handle Decimal, datetime, etc.
-                    aircraft_details_json = json.dumps(flight_data.get("details", []), default=_json_default)
-                    hourly_json = json.dumps(flight_data.get("hourly_breakdown", {}), default=_json_default)
-                    await session.execute(text("""
-                        UPDATE controller_summaries
-                        SET aircraft_details = :aircraft_details, total_aircraft_handled = :total, peak_aircraft_count = :peak, hourly_aircraft_breakdown = :hourly, enrichment_status = 'completed', enrichment_completed_at = now(), updated_at = now()
-                        WHERE id = :id
-                    """), {
-                        "aircraft_details": aircraft_details_json,
-                        "total": flight_data.get("total_aircraft", 0),
-                        "peak": flight_data.get("peak_count", 0),
-                        "hourly": hourly_json,
-                        "id": cid
-                    })
-                    await session.commit()
-
-                logger.info(f"Controller enrichment completed id={cid} callsign={callsign}")
-                return True
-
-            return False
+                        # Use custom default serializer
+                        import json
+                        aircraft_details_json = json.dumps(flight_data.get("details", []), default=_json_default)
+                        hourly_json = json.dumps(flight_data.get("hourly_breakdown", {}), default=_json_default)
+                        
+                        await session.execute(text("""
+                            UPDATE controller_summaries
+                            SET aircraft_details = :aircraft_details, 
+                                total_aircraft_handled = :total, 
+                                peak_aircraft_count = :peak, 
+                                hourly_aircraft_breakdown = :hourly, 
+                                enrichment_status = 'completed', 
+                                enrichment_completed_at = now(), 
+                                enrichment_last_error = NULL,
+                                updated_at = now()
+                            WHERE id = :id
+                        """), {
+                            "aircraft_details": aircraft_details_json,
+                            "total": flight_data.get("total_aircraft", 0),
+                            "peak": flight_data.get("peak_count", 0),
+                            "hourly": hourly_json,
+                            "id": controller_job["id"]
+                        })
+                        
+                        await session.commit()
+                        logger.info(f"Controller enrichment completed id={controller_job['id']} callsign={controller_job['callsign']}")
+                        return True
+                        
+                    except Exception as e:
+                        logger.exception(f"Controller enrichment failed for id={controller_job['id']} callsign={controller_job['callsign']}: {e}")
+                        await session.execute(text("""
+                            UPDATE controller_summaries
+                            SET enrichment_status = 'pending', 
+                                enrichment_run_after = now() + interval '60 seconds', 
+                                enrichment_last_error = :err, 
+                                updated_at = now()
+                            WHERE id = :id
+                        """), {"err": str(e), "id": controller_job["id"]})
+                        await session.commit()
+                        return False
 
         except Exception as e:
-            logger.exception(f"Enrichment failed: {e}")
-            async with get_database_session() as session:
-                if fs_id:
-                    await session.execute(text("""
-                        UPDATE flight_summaries
-                        SET enrichment_status = 'pending', enrichment_run_after = now() + interval '60 seconds', enrichment_last_error = :err, updated_at = now()
-                        WHERE id = :id
-                    """), {"err": str(e), "id": fs_id})
-                if controller_job:
-                    await session.execute(text("""
-                        UPDATE controller_summaries
-                        SET enrichment_status = 'pending', enrichment_run_after = now() + interval '60 seconds', enrichment_last_error = :err, updated_at = now()
-                        WHERE id = :id
-                    """), {"err": str(e), "id": controller_job["id"]})
-                await session.commit()
+            logger.exception(f"Critical error in enrichment worker: {e}")
             return False
+
 
     async def run_loop(self):
         while True:

--- a/recovery_cleanup.sql
+++ b/recovery_cleanup.sql
@@ -1,0 +1,88 @@
+-- Recovery script to clean up existing stuck enrichment flights
+-- This addresses the backlog of flights with excessive retry counts
+
+BEGIN;
+
+-- Step 1: Show current state before cleanup
+SELECT 'BEFORE CLEANUP:' as status;
+SELECT 
+    enrichment_status,
+    COUNT(*) as count,
+    ROUND(AVG(enrichment_attempts), 2) as avg_attempts,
+    MAX(enrichment_attempts) as max_attempts
+FROM flight_summaries 
+GROUP BY enrichment_status 
+ORDER BY enrichment_status;
+
+-- Step 2: Reset flights with excessive retry counts (100+)
+UPDATE flight_summaries 
+SET 
+    enrichment_attempts = 0,
+    enrichment_status = 'pending',
+    enrichment_run_after = NOW(),
+    enrichment_last_error = 'Reset due to excessive retries - recovery script',
+    updated_at = NOW()
+WHERE enrichment_attempts >= 100 
+  AND enrichment_status = 'pending'
+  AND completion_time IS NOT NULL;
+
+-- Show how many were reset
+SELECT 'FLIGHTS RESET (100+ attempts):' as status;
+SELECT COUNT(*) as flights_reset 
+FROM flight_summaries 
+WHERE enrichment_last_error = 'Reset due to excessive retries - recovery script';
+
+-- Step 3: Reset flights stuck in 'in_progress' for too long
+UPDATE flight_summaries
+SET enrichment_status = 'pending',
+    enrichment_run_after = NOW(),
+    enrichment_last_error = 'Recovered from stuck in_progress status - recovery script',
+    updated_at = NOW()
+WHERE enrichment_status = 'in_progress' 
+  AND updated_at < NOW() - INTERVAL '5 minutes';
+
+-- Show recovery results
+SELECT 'STUCK IN_PROGRESS RECOVERED:' as status;
+SELECT COUNT(*) as flights_recovered
+FROM flight_summaries 
+WHERE enrichment_last_error = 'Recovered from stuck in_progress status - recovery script';
+
+-- Step 4: Show state after cleanup
+SELECT 'AFTER CLEANUP:' as status;
+SELECT 
+    enrichment_status,
+    COUNT(*) as count,
+    ROUND(AVG(enrichment_attempts), 2) as avg_attempts,
+    MAX(enrichment_attempts) as max_attempts
+FROM flight_summaries 
+GROUP BY enrichment_status 
+ORDER BY enrichment_status;
+
+-- Step 5: Show distribution of remaining high-attempt flights
+SELECT 'REMAINING HIGH-ATTEMPT FLIGHTS:' as status;
+SELECT 
+    CASE 
+        WHEN enrichment_attempts >= 50 THEN '50+ attempts'
+        WHEN enrichment_attempts >= 20 THEN '20-49 attempts'
+        WHEN enrichment_attempts >= 10 THEN '10-19 attempts'
+        WHEN enrichment_attempts >= 5 THEN '5-9 attempts'
+        ELSE '0-4 attempts'
+    END as attempt_range,
+    COUNT(*) as count
+FROM flight_summaries 
+WHERE enrichment_status = 'pending'
+GROUP BY 
+    CASE 
+        WHEN enrichment_attempts >= 50 THEN '50+ attempts'
+        WHEN enrichment_attempts >= 20 THEN '20-49 attempts'
+        WHEN enrichment_attempts >= 10 THEN '10-19 attempts'
+        WHEN enrichment_attempts >= 5 THEN '5-9 attempts'
+        ELSE '0-4 attempts'
+    END
+ORDER BY count DESC;
+
+COMMIT;
+
+-- Final summary
+SELECT 'RECOVERY COMPLETE' as status;
+SELECT NOW() as completed_at;


### PR DESCRIPTION
- Fix transaction atomicity: run entire enrichment process in single transaction
- Add automatic stuck flight recovery (resets in_progress flights >5min old)
- Add excessive retry reset (resets flights with 100+ attempts)
- Prevent flights from getting permanently stuck in in_progress status
- Eliminate silent failures with proper error handling and rollback
- Add recovery cleanup script for existing stuck flights

Resolves enrichment queueing issue where flights accumulated high retry counts without completing due to worker crashes/restarts leaving them stuck.