### PR TITLE
EMERGENCY FIX: Stop massive rescheduling loop

### DIFF
--- a/app/services/summary_enrichment_worker.py
+++ b/app/services/summary_enrichment_worker.py
@@ -135,12 +135,13 @@ class SummaryEnrichmentWorker:
                     for flight in failed_flights:
                         logger.error(f"PERMANENT_RETRY_LOOP_STOPPED: flight id={flight.id}, callsign={flight.callsign}, attempts={flight.enrichment_attempts}")
                 
-                # Reset moderate retry counts with exponential backoff (ONLY for 20-49 attempts)
+                # TEMPORARILY DISABLED: Reset moderate retry counts with exponential backoff
+                # This was causing mass resets that created traffic jams
+                # Instead, just mark them as failed permanently
                 result = await session.execute(text("""
                     UPDATE flight_summaries
-                    SET enrichment_attempts = 0,
-                        enrichment_run_after = NOW() + INTERVAL '1 hour',
-                        enrichment_last_error = COALESCE(enrichment_last_error, '') || ' | RESET_WITH_BACKOFF: Retry loop prevention',
+                    SET enrichment_status = 'failed',
+                        enrichment_last_error = 'PERMANENT_FAIL: High retry count (20-49 attempts) - DISABLED_RESET_WITH_BACKOFF',
                         updated_at = NOW()
                     WHERE enrichment_attempts BETWEEN 20 AND 49
                     AND enrichment_status = 'pending'
@@ -150,9 +151,9 @@ class SummaryEnrichmentWorker:
                 
                 reset_flights = result.fetchall()
                 if reset_flights:
-                    logger.warning(f"Reset {len(reset_flights)} flights with 1-hour backoff to prevent retry loops")
+                    logger.warning(f"PERMANENTLY_FAILED {len(reset_flights)} flights with 20-49 attempts (disabled reset_with_backoff)")
                     for flight in reset_flights:
-                        logger.info(f"BACKOFF_APPLIED: flight id={flight.id}, callsign={flight.callsign}, attempts={flight.enrichment_attempts}")
+                        logger.info(f"PERMANENT_FAIL: flight id={flight.id}, callsign={flight.callsign}, attempts={flight.enrichment_attempts}")
                 
                 await session.commit()
                 
@@ -300,14 +301,16 @@ class SummaryEnrichmentWorker:
                     except Exception as e:
                         # On any error, reset to pending with proper error logging
                         logger.exception(f"Enrichment failed for id={fs_id} callsign={callsign}: {e}")
+                        # Use exponential backoff based on attempt count
+                        backoff_minutes = min(60, 2 ** current_attempts)  # 2, 4, 8, 16, 32, 60 minutes max
                         await session.execute(text("""
                             UPDATE flight_summaries
                             SET enrichment_status = 'pending', 
-                                enrichment_run_after = now() + interval '60 seconds', 
+                                enrichment_run_after = now() + interval ':backoff minutes', 
                                 enrichment_last_error = :err, 
                                 updated_at = now()
                             WHERE id = :id
-                        """), {"err": str(e), "id": fs_id})
+                        """), {"err": str(e), "id": fs_id, "backoff": backoff_minutes})
                         await session.commit()
                         return False
                 else:
@@ -377,14 +380,22 @@ class SummaryEnrichmentWorker:
                         
                     except Exception as e:
                         logger.exception(f"Controller enrichment failed for id={controller_job['id']} callsign={controller_job['callsign']}: {e}")
+                        # Get current attempt count for exponential backoff
+                        attempt_result = await session.execute(text("""
+                            SELECT COALESCE(enrichment_attempts, 0) as attempts FROM controller_summaries WHERE id = :id
+                        """), {"id": controller_job["id"]})
+                        current_attempts = attempt_result.fetchone().attempts
+                        
+                        # Use exponential backoff based on attempt count
+                        backoff_minutes = min(60, 2 ** current_attempts)  # 2, 4, 8, 16, 32, 60 minutes max
                         await session.execute(text("""
                             UPDATE controller_summaries
                             SET enrichment_status = 'pending', 
-                                enrichment_run_after = now() + interval '60 seconds', 
+                                enrichment_run_after = now() + interval ':backoff minutes', 
                                 enrichment_last_error = :err, 
                                 updated_at = now()
                             WHERE id = :id
-                        """), {"err": str(e), "id": controller_job["id"]})
+                        """), {"err": str(e), "id": controller_job["id"], "backoff": backoff_minutes})
                         await session.commit()
                         return False
 

--- a/production_emergency_cleanup.sql
+++ b/production_emergency_cleanup.sql
@@ -1,0 +1,70 @@
+-- EMERGENCY PRODUCTION CLEANUP
+-- Fix the massive rescheduling loop by cleaning up backoff flights
+-- Run this immediately in production
+
+BEGIN;
+
+-- 1. Mark all flights with 20-49 attempts as permanently failed (disable reset_with_backoff)
+UPDATE flight_summaries
+SET enrichment_status = 'failed',
+    enrichment_last_error = 'EMERGENCY_FIX: High retry count (20-49 attempts) - disabled reset_with_backoff',
+    updated_at = NOW()
+WHERE enrichment_attempts BETWEEN 20 AND 49
+AND enrichment_status = 'pending'
+AND completion_time IS NOT NULL;
+
+-- 2. Mark all flights with 50+ attempts as permanently failed (already should be, but ensure)
+UPDATE flight_summaries
+SET enrichment_status = 'failed',
+    enrichment_last_error = 'EMERGENCY_FIX: Infinite retry loop (50+ attempts) - permanently failed',
+    updated_at = NOW()
+WHERE enrichment_attempts >= 50
+AND enrichment_status = 'pending'
+AND completion_time IS NOT NULL;
+
+-- 3. Reset flights with 10-19 attempts to longer backoff (4-8 hours instead of immediate retry)
+UPDATE flight_summaries
+SET enrichment_run_after = NOW() + INTERVAL '4 hours',
+    enrichment_last_error = COALESCE(enrichment_last_error, '') || ' | EMERGENCY_FIX: Extended backoff to reduce load',
+    updated_at = NOW()
+WHERE enrichment_attempts BETWEEN 10 AND 19
+AND enrichment_status = 'pending'
+AND enrichment_run_after <= NOW()
+AND completion_time IS NOT NULL;
+
+-- 4. Reset flights with 5-9 attempts to moderate backoff (1-2 hours)
+UPDATE flight_summaries
+SET enrichment_run_after = NOW() + INTERVAL '1 hour',
+    enrichment_last_error = COALESCE(enrichment_last_error, '') || ' | EMERGENCY_FIX: Moderate backoff to reduce load',
+    updated_at = NOW()
+WHERE enrichment_attempts BETWEEN 5 AND 9
+AND enrichment_status = 'pending'
+AND enrichment_run_after <= NOW()
+AND completion_time IS NOT NULL;
+
+-- 5. Show the impact
+SELECT 
+    'Before cleanup' as status,
+    COUNT(*) as count,
+    MIN(enrichment_attempts) as min_attempts,
+    MAX(enrichment_attempts) as max_attempts,
+    COUNT(CASE WHEN enrichment_run_after <= NOW() THEN 1 END) as ready_for_processing
+FROM flight_summaries 
+WHERE enrichment_status = 'pending'
+AND completion_time IS NOT NULL;
+
+COMMIT;
+
+-- Show final status
+SELECT 
+    'After cleanup' as status,
+    COUNT(*) as total_pending,
+    COUNT(CASE WHEN enrichment_attempts = 0 THEN 1 END) as zero_attempts,
+    COUNT(CASE WHEN enrichment_attempts BETWEEN 1 AND 4 THEN 1 END) as low_attempts,
+    COUNT(CASE WHEN enrichment_attempts BETWEEN 5 AND 9 THEN 1 END) as moderate_attempts,
+    COUNT(CASE WHEN enrichment_attempts BETWEEN 10 AND 19 THEN 1 END) as high_attempts,
+    COUNT(CASE WHEN enrichment_attempts >= 20 THEN 1 END) as very_high_attempts,
+    COUNT(CASE WHEN enrichment_run_after <= NOW() THEN 1 END) as ready_for_processing
+FROM flight_summaries 
+WHERE enrichment_status = 'pending'
+AND completion_time IS NOT NULL;


### PR DESCRIPTION
- Disable RESET_WITH_BACKOFF to prevent mass resets (1,583 flights ready simultaneously)
- Implement exponential backoff: 2, 4, 8, 16, 32, 60 minutes based on attempt count
- Mark high-attempt flights (20-49) as permanently failed instead of resetting
- Add production cleanup script to handle existing backoff flights
- Reduces requeue-to-completion ratio from 18:1 to manageable levels

Addresses: 10,687 pending flights, 5,039 requeues/10min vs 275 completions/10min