### PR TITLE
Fix flight summary retry limit enforcement

### DIFF
--- a/app/services/summary_enrichment_worker.py
+++ b/app/services/summary_enrichment_worker.py
@@ -187,10 +187,11 @@ class SummaryEnrichmentWorker:
                     WHERE enrichment_status = 'pending' 
                     AND enrichment_run_after <= now() 
                     AND completion_time IS NOT NULL
+                    AND COALESCE(enrichment_attempts, 0) < :max_retries
                     LIMIT 1
                     FOR UPDATE SKIP LOCKED
                 """)
-                res = await session.execute(claim_flight_sql)
+                res = await session.execute(claim_flight_sql, {"max_retries": MAX_ENRICHMENT_RETRIES})
                 row = res.fetchone()
                 
                 if row:


### PR DESCRIPTION
- Add retry limit filter to flight summary SELECT query
- Flights with 5+ attempts are now excluded from selection
- Prevents worker from claiming flights that should be marked as failed
- Fixes issue where flights with 220+ attempts were still being processed
- Only affects flight_summaries, controller_summaries unchanged

The SELECT query now includes:
AND COALESCE(enrichment_attempts, 0) < :max_retries

This ensures flights exceeding MAX_ENRICHMENT_RETRIES (5) are never selected for processing, forcing them to be marked as failed by the _stop_infinite_retry_loops() method instead.