### PR TITLE
fix: Implement database sequence verification during startup

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -16,6 +16,8 @@ from sqlalchemy.pool import QueuePool, NullPool
 from sqlalchemy.exc import SQLAlchemyError
 import asyncio
 
+from app.sequence_verification import verify_and_sync_sequences
+
 from app.config import get_config
 from app.utils.logging import get_logger_for_module
 from app.utils.error_handling import handle_service_errors, log_operation
@@ -271,6 +273,21 @@ async def init_db():
             async with async_session_factory() as session:
                 result = await session.execute(text("SELECT 1"))
                 logger.info("✅ Asynchronous database connection successful")
+                
+                # Verify and sync database sequences to prevent primary key conflicts
+                try:
+                    logger.info("🔍 Verifying database sequences...")
+                    success = await verify_and_sync_sequences(session)
+                    if success:
+                        logger.info("✅ Database sequences verified and synced successfully")
+                    else:
+                        error_msg = "🚨 CRITICAL: Database sequence verification failed"
+                        logger.critical(error_msg)
+                        raise RuntimeError("Database sequence verification failed - cannot start with misaligned sequences")
+                except Exception as seq_error:
+                    error_msg = f"🚨 CRITICAL: Database sequence verification error: {seq_error}"
+                    logger.critical(error_msg)
+                    raise RuntimeError(f"Database sequence error: {seq_error}")
         except Exception as e:
             error_msg = f"🚨 CRITICAL: Asynchronous database connection failed: {e}"
             logger.critical(error_msg)

--- a/app/main.py
+++ b/app/main.py
@@ -38,6 +38,7 @@ from app.services.vatsim_service import get_vatsim_service
 from app.services.data_service import get_data_service
 from app.services.summary_enrichment_worker import SummaryEnrichmentWorker
 from app.database import get_database_session
+from app.sequence_verification import verify_and_sync_sequences
 from app.models import Flight, Controller, Transceiver
 # Simple configuration for main.py
 class SimpleConfig:
@@ -126,6 +127,15 @@ async def lifespan(app: FastAPI):
             # Test basic connection
             await session.execute(text("SELECT 1"))
             logger.info("✅ Database connection successful")
+            
+            # Verify sequence alignment to prevent primary key conflicts
+            logger.info("🔍 Verifying database sequences...")
+            success = await verify_and_sync_sequences(session)
+            if not success:
+                error_msg = "🚨 CRITICAL: Database sequence verification failed"
+                logger.critical(error_msg)
+                exit_application("Database sequence verification failed - cannot start with misaligned sequences")
+            logger.info("✅ Database sequences verified and synced successfully")
             
             # Check if all required tables exist - MORE ROBUST VALIDATION
             logger.info("🔍 Verifying database schema...")

--- a/app/sequence_verification.py
+++ b/app/sequence_verification.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Database sequence verification and synchronization utility.
+
+This module provides functions to verify and synchronize PostgreSQL sequences
+with their respective table data to prevent primary key conflicts.
+"""
+
+import logging
+from sqlalchemy import text
+
+logger = logging.getLogger(__name__)
+
+async def verify_and_sync_sequences(session):
+    """
+    Verify that all PostgreSQL sequences are properly aligned with their tables 
+    and reset them if necessary.
+    
+    This function should be called during application startup to prevent
+    primary key conflicts due to sequence-data inconsistencies.
+    
+    Args:
+        session: SQLAlchemy async session
+        
+    Returns:
+        bool: True if all sequences are properly aligned or were successfully reset
+    """
+    try:
+        # Get a list of all tables with sequences, filtering only user tables
+        result = await session.execute(text("""
+            SELECT 
+                c.relname as table_name,
+                a.attname as column_name,
+                pg_get_serial_sequence(c.relname, a.attname) as sequence_name
+            FROM 
+                pg_class c
+            JOIN 
+                pg_attribute a ON a.attrelid = c.oid
+            JOIN
+                pg_namespace n ON n.oid = c.relnamespace
+            WHERE 
+                c.relkind = 'r' AND
+                n.nspname = 'public' AND
+                a.attnum > 0 AND 
+                NOT a.attisdropped AND
+                pg_get_serial_sequence(c.relname, a.attname) IS NOT NULL
+        """))
+        
+        sequences = result.fetchall()
+        logger.info(f"Verifying {len(sequences)} sequences")
+        
+        # Check and reset each sequence if needed
+        sequences_fixed = 0
+        for seq in sequences:
+            table_name = seq.table_name
+            column_name = seq.column_name
+            sequence_name = seq.sequence_name
+            
+            # Skip system tables
+            if table_name.startswith('pg_') or table_name.startswith('sql_'):
+                continue
+            
+            # Get the current sequence value
+            seq_result = await session.execute(text(f"SELECT last_value FROM {sequence_name}"))
+            current_seq = seq_result.scalar() or 0
+            
+            # Get the maximum ID from the table
+            max_id_result = await session.execute(text(f"SELECT MAX({column_name}) FROM {table_name}"))
+            max_id = max_id_result.scalar() or 0
+            
+            if max_id > 0 and current_seq < max_id:
+                new_seq_value = max_id + 1
+                logger.warning(
+                    f"Table {table_name}: Sequence {sequence_name} ({current_seq}) "
+                    f"is behind MAX({column_name}) ({max_id}), resetting to {new_seq_value}"
+                )
+                
+                # Reset the sequence
+                await session.execute(
+                    text(f"SELECT setval('{sequence_name}', {new_seq_value}, false)")
+                )
+                sequences_fixed += 1
+        
+        # Commit all changes
+        await session.commit()
+        
+        if sequences_fixed > 0:
+            logger.info(f"✅ Reset {sequences_fixed} sequences that were behind their table data")
+        else:
+            logger.info("✅ All sequences are properly aligned with their table data")
+            
+        return True
+        
+    except Exception as e:
+        logger.error(f"Error verifying sequences: {e}")
+        await session.rollback()
+        return False

--- a/fix_flights_sequence.py
+++ b/fix_flights_sequence.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Reset the flights_id_seq sequence to prevent primary key conflicts.
+
+This script fixes the critical issue where PostgreSQL sequence is out of sync
+with the actual data in the flights table, causing primary key constraint violations
+during flight data insertion.
+"""
+
+import asyncio
+import logging
+from sqlalchemy import text
+from app.database import get_database_session
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+async def reset_flights_sequence():
+    """Reset the flights_id_seq sequence to MAX(id) + 1"""
+    async with get_database_session() as session:
+        try:
+            # Get the current sequence value
+            seq_result = await session.execute(text("SELECT last_value FROM flights_id_seq"))
+            current_seq = seq_result.scalar() or 0
+            
+            # Get the maximum ID from the flights table
+            max_id_result = await session.execute(text("SELECT MAX(id) FROM flights"))
+            max_id = max_id_result.scalar() or 0
+            
+            logger.info(f"Current sequence value: {current_seq}")
+            logger.info(f"Maximum ID in flights table: {max_id}")
+            
+            # Only reset if sequence is behind max ID
+            if current_seq <= max_id:
+                new_seq_value = max_id + 1
+                await session.execute(
+                    text(f"SELECT setval('flights_id_seq', {new_seq_value}, false)")
+                )
+                logger.info(f"Reset flights_id_seq to {new_seq_value}")
+                
+                # Verify the update was successful
+                verify_result = await session.execute(text("SELECT last_value FROM flights_id_seq"))
+                new_seq = verify_result.scalar() or 0
+                logger.info(f"Verified new sequence value: {new_seq}")
+                
+                if new_seq != new_seq_value:
+                    logger.error(f"Sequence reset verification failed! Expected {new_seq_value}, got {new_seq}")
+            else:
+                logger.info("Sequence is already ahead of maximum ID, no reset needed")
+            
+            await session.commit()
+            return True
+        except Exception as e:
+            logger.error(f"Failed to reset flights sequence: {e}")
+            await session.rollback()
+            return False
+
+async def check_other_sequences():
+    """Check if other tables might have similar sequence issues"""
+    async with get_database_session() as session:
+        try:
+            # Get a list of all tables with sequences
+            result = await session.execute(text("""
+                SELECT 
+                    c.relname as table_name,
+                    a.attname as column_name,
+                    pg_get_serial_sequence(c.relname, a.attname) as sequence_name
+                FROM 
+                    pg_class c
+                JOIN 
+                    pg_attribute a ON a.attrelid = c.oid
+                WHERE 
+                    c.relkind = 'r' AND
+                    a.attnum > 0 AND 
+                    NOT a.attisdropped AND
+                    pg_get_serial_sequence(c.relname, a.attname) IS NOT NULL
+            """))
+            
+            sequences = result.fetchall()
+            logger.info(f"Found {len(sequences)} tables with sequences")
+            
+            # Check each sequence
+            for seq in sequences:
+                table_name = seq.table_name
+                column_name = seq.column_name
+                sequence_name = seq.sequence_name
+                
+                # Skip system tables
+                if table_name.startswith('pg_') or table_name.startswith('sql_'):
+                    continue
+                
+                # Get the current sequence value
+                seq_result = await session.execute(text(f"SELECT last_value FROM {sequence_name}"))
+                current_seq = seq_result.scalar() or 0
+                
+                # Get the maximum ID from the table
+                max_id_result = await session.execute(text(f"SELECT MAX({column_name}) FROM {table_name}"))
+                max_id = max_id_result.scalar() or 0
+                
+                if max_id > 0 and current_seq <= max_id:
+                    logger.warning(f"Table {table_name}: Sequence {sequence_name} ({current_seq}) is behind MAX({column_name}) ({max_id})")
+                    
+            return True
+        except Exception as e:
+            logger.error(f"Error checking sequences: {e}")
+            return False
+
+async def main():
+    """Main entry point."""
+    logger.info("Starting fix_flights_sequence script")
+    
+    # Reset the flights_id_seq
+    success = await reset_flights_sequence()
+    if success:
+        logger.info("Flights sequence reset completed successfully")
+    else:
+        logger.error("Failed to reset flights sequence")
+    
+    # Check other sequences
+    logger.info("Checking other sequences for potential issues...")
+    await check_other_sequences()
+    
+    logger.info("Script completed")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/migrations/reset_flights_sequence.sql
+++ b/migrations/reset_flights_sequence.sql
@@ -1,0 +1,56 @@
+-- Reset the flights_id_seq sequence to prevent primary key conflicts
+-- This fixes the critical issue where PostgreSQL sequence is out of sync
+-- with the actual data in the flights table, causing primary key constraint violations
+
+-- Get the current sequence value and max ID for diagnosis
+SELECT 
+    'Current State' as description,
+    (SELECT last_value FROM flights_id_seq) as sequence_value,
+    (SELECT MAX(id) FROM flights) as max_id,
+    (SELECT MIN(id) FROM flights) as min_id,
+    (SELECT COUNT(*) FROM flights) as total_records;
+
+-- Reset the sequence to max ID + 1
+SELECT setval('flights_id_seq', (SELECT MAX(id) FROM flights) + 1, false);
+
+-- Verify the change
+SELECT 
+    'After Reset' as description,
+    (SELECT last_value FROM flights_id_seq) as sequence_value,
+    (SELECT MAX(id) FROM flights) as max_id;
+
+-- Check other sequences for similar issues (diagnostic only)
+WITH sequence_info AS (
+    SELECT 
+        c.relname as table_name,
+        a.attname as column_name,
+        pg_get_serial_sequence(c.relname, a.attname) as sequence_name
+    FROM 
+        pg_class c
+    JOIN 
+        pg_attribute a ON a.attrelid = c.oid
+    WHERE 
+        c.relkind = 'r' AND
+        a.attnum > 0 AND 
+        NOT a.attisdropped AND
+        pg_get_serial_sequence(c.relname, a.attname) IS NOT NULL
+)
+SELECT 
+    s.table_name,
+    s.column_name,
+    s.sequence_name,
+    (SELECT last_value FROM pg_sequences WHERE sequencename = split_part(s.sequence_name, '.', 2)) as sequence_value,
+    (SELECT MAX(CAST(a.attname AS text)::int) FROM pg_attribute a WHERE a.attrelid = s.table_name::regclass) as max_id,
+    CASE WHEN 
+        (SELECT MAX(CAST(a.attname AS text)::int) FROM pg_attribute a WHERE a.attrelid = s.table_name::regclass) >
+        (SELECT last_value FROM pg_sequences WHERE sequencename = split_part(s.sequence_name, '.', 2))
+    THEN 'OUT OF SYNC'
+    ELSE 'OK'
+    END as status
+FROM 
+    sequence_info s
+WHERE 
+    NOT s.table_name LIKE 'pg_%' AND
+    NOT s.table_name LIKE 'sql_%'
+ORDER BY 
+    s.table_name;


### PR DESCRIPTION
This commit addresses critical sequence-data inconsistency issues that caused primary key constraint violations in the flights table.

Key changes:
1. Added sequence_verification module to detect and fix misaligned sequences
2. Integrated verification into application startup flow in main.py
3. Added fail-fast behavior to prevent running with misaligned sequences
4. Added SQL migration script for immediate production fixes
5. Added Python utility script for ad-hoc fixes via application code
6. Fixed comparison logic to only reset sequences when truly behind data

The verification occurs during application startup and ensures all tables have their sequences properly aligned with their maximum ID values. If a sequence is behind its table's maximum ID, it gets automatically reset to prevent future primary key conflicts.

Fixes issue: "duplicate key value violates unique constraint flights_pkey"